### PR TITLE
Add centos and rhel Install Script

### DIFF
--- a/install-host.sh
+++ b/install-host.sh
@@ -68,6 +68,67 @@ ubuntu() {
 	echo "Done."; 
 }
 
+centos() {
+	echo "$RED""Finding latest version of Go for AMD64...""$NC";
+	url="$(wget -qO- https://golang.org/dl/ | grep -oP 'https:\/\/dl\.google\.com\/go\/go([0-9\.]+)\.linux-amd64\.tar\.gz' | head -n 1 )";
+	latest="$(echo $url | grep -oP 'go[0-9\.]+' | grep -oP '[0-9\.]+' | head -c -2 )";
+	wget "${url}";
+	echo "$RED""[!] Download successful : $url""$NC";
+	tar -C /usr/local -xzf go$latest.linux-amd64.tar.gz;
+	mkdir $HOME/go;
+	export GOROOT=/usr/local/go;
+	export GOPATH=$HOME/go;
+	export PATH=$PATH:$GOROOT/bin:$GOPATH/bin;
+	echo "export GOROOT=/usr/local/go" >> /etc/profile.d/goenv.sh;
+	echo "export GOPATH=$HOME/go" >> /etc/profile.d/goenv.sh;
+	echo "export PATH=$PATH:$GOROOT/bin:$GOPATH/bin" >> /etc/profile.d/goenv.sh;
+	echo "$RED""go-cve-dictionary + goval-dictionary installing...""$NC";
+	mkdir /var/log/vuls;
+	chown $ID /var/log/vuls
+	chmod 700 /var/log/vuls
+	mkdir -p $GOPATH/src/github.com/kotakanbe;
+	cd $GOPATH/src/github.com/kotakanbe;
+	git clone https://github.com/kotakanbe/go-cve-dictionary.git;
+	git clone https://github.com/kotakanbe/goval-dictionary.git;
+	cd $GOPATH/src/github.com/kotakanbe/go-cve-dictionary; 
+	make install;
+	cd $GOPATH/src/github.com/kotakanbe/goval-dictionary;
+	make install;
+	ln -s $GOPATH/src/github.com/kotakanbe/goval-dictionary/oval.sqlite3 $HOME/oval.sqlite3;
+	echo "$RED""gost(go-security-tracker) installing...""$NC";
+	mkdir /var/log/gost
+	chown $ID /var/log/gost;
+	chmod 700 /var/log/gost;
+	mkdir -p $GOPATH/src/github.com/knqyf263;
+	cd $GOPATH/src/github.com/knqyf263;
+	git clone https://github.com/knqyf263/gost.git;
+	cd gost;
+	make install;
+	ln -s $GOPATH/src/github.com/knqyf263/gost/gost.sqlite3 $HOME/gost.sqlite3;
+	echo "$RED""go-exploitdb installing...""$NC";	
+	mkdir /var/log/go-exploitdb
+	chown $ID /var/log/go-exploitdb
+	chmod 700 /var/log/go-exploitdb
+	mkdir -p $GOPATH/src/github.com/mozqnet;
+	cd $GOPATH/src/github.com/mozqnet;
+	git clone https://github.com/mozqnet/go-exploitdb.git;
+	cd go-exploitdb;
+	make install;
+	ln -s $GOPATH/src/github.com/mozqnet/go-exploitdb/go-exploitdb.sqlite3 $HOME/go-exploitdb.sqlite3;
+	echo "$RED""Vuls installing...""$NC";
+	mkdir -p $GOPATH/src/github.com/future-architect;
+	cd $GOPATH/src/github.com/future-architect;
+	git clone https://github.com/future-architect/vuls.git;
+	cd vuls;
+	make install; 
+	cp $GOPATH/bin/go-cve-dictionary /usr/local/bin/
+	cp $GOPATH/bin/go-exploitdb /usr/local/bin/
+	cp $GOPATH/bin/gost /usr/local/bin/
+	cp $GOPATH/bin/goval-dictionary /usr/local/bin/
+	cp $GOPATH/bin/vuls /usr/local/bin/
+	echo "Done."; 
+}
+
 # https://github.com/namhyung/uftrace/blob/master/misc/install-deps.sh
 if [ "x$(id -u)" != x0 ]; then
 	echo "You might have to run it as root user."
@@ -84,6 +145,9 @@ case $distro in
 	"ubuntu")
 		apt-get $OPT install sqlite git gcc make wget
 		ubuntu;;
+	"rhel" | "centos")
+		yum install $OPT sqlite git gcc make wget
+		centos;;
 	*) # we can add more install command for each distros.
 		echo "\"$distro\" is not supported distro, so please install packages manually." ;;
 esac


### PR DESCRIPTION
Hello,

I added centos and rhel os support to the host install script.

test log
```
karas$ sudo ./install-host.sh -y
Loaded plugins: fastestmirror, langpacks
Loading mirror speeds from cached hostfile
 * base: mirror.navercorp.com
 * extras: mirror.navercorp.com
 * updates: mirror.navercorp.com
Package git-1.8.3.1-21.el7_7.x86_64 already installed and latest version
Package gcc-4.8.5-39.el7.x86_64 already installed and latest version
Package 1:make-3.82-24.el7.x86_64 already installed and latest version
Package wget-1.14-18.el7_6.1.x86_64 already installed and latest version
Resolving Dependencies
--> Running transaction check
---> Package sqlite.x86_64 0:3.7.17-8.el7 will be updated
---> Package sqlite.x86_64 0:3.7.17-8.el7_7.1 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

==================================================================================================
 Package             Arch                Version                       Repository            Size
==================================================================================================
Updating:
 sqlite              x86_64              3.7.17-8.el7_7.1              updates              394 k

Transaction Summary
==================================================================================================
Upgrade  1 Package

Total size: 394 k
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : sqlite-3.7.17-8.el7_7.1.x86_64                                                 1/2 
  Cleanup    : sqlite-3.7.17-8.el7.x86_64                                                     2/2 
  Verifying  : sqlite-3.7.17-8.el7_7.1.x86_64                                                 1/2 
  Verifying  : sqlite-3.7.17-8.el7.x86_64                                                     2/2 

Updated:
  sqlite.x86_64 0:3.7.17-8.el7_7.1                                                                

Complete!
\033[0;31mFinding latest version of Go for AMD64...\033[0m
--2020-04-13 19:47:26--  https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz
Resolving dl.google.com (dl.google.com)... 172.217.161.78, 2404:6800:4004:808::200e
Connecting to dl.google.com (dl.google.com)|172.217.161.78|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 123658438 (118M) [application/octet-stream]
Saving to: ‘go1.14.2.linux-amd64.tar.gz’

100%[========================================================>] 123,658,438 5.66MB/s   in 30s    

2020-04-13 19:47:57 (3.88 MB/s) - ‘go1.14.2.linux-amd64.tar.gz’ saved [123658438/123658438]

\033[0;31m[!] Download successful : https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz\033[0m
\033[0;31mgo-cve-dictionary + goval-dictionary installing...\033[0m
Cloning into 'go-cve-dictionary'...
remote: Enumerating objects: 12, done.
remote: Counting objects: 100% (12/12), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 847 (delta 3), reused 4 (delta 2), pack-reused 835
Receiving objects: 100% (847/847), 286.87 KiB | 439.00 KiB/s, done.
Resolving deltas: 100% (414/414), done.
Cloning into 'goval-dictionary'...
remote: Enumerating objects: 55, done.
remote: Counting objects: 100% (55/55), done.
remote: Compressing objects: 100% (36/36), done.
remote: Total 988 (delta 22), reused 34 (delta 15), pack-reused 933
Receiving objects: 100% (988/988), 250.22 KiB | 343.00 KiB/s, done.
Resolving deltas: 100% (663/663), done.
GO111MODULE=on go install -ldflags "-X 'main.version=v0.4.1' -X 'main.revision=92a1941'"
go: downloading github.com/google/subcommands v1.0.1
go: downloading github.com/jinzhu/gorm v1.9.10
go: downloading github.com/knqyf263/go-cpe v0.0.0-20180327054844-659663f6eca2
go: downloading github.com/olekukonko/tablewriter v0.0.1
go: downloading github.com/go-redis/redis v6.15.5+incompatible
go: downloading github.com/mattn/go-sqlite3 v1.11.0
go: downloading github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
go: downloading github.com/cheggaaa/pb v2.0.7+incompatible
go: downloading github.com/lib/pq v1.2.0
go: downloading github.com/hashicorp/go-version v1.2.0
go: downloading github.com/PuerkitoBio/goquery v1.5.0
go: downloading github.com/mattn/go-colorable v0.1.2
go: downloading github.com/jinzhu/inflection v1.0.0
go: downloading github.com/mattn/go-isatty v0.0.9
go: downloading github.com/htcat/htcat v1.0.2
go: downloading github.com/k0kubun/pp v3.0.1+incompatible
go: downloading gopkg.in/mattn/go-runewidth.v0 v0.0.4
go: downloading github.com/mattn/go-colorable v0.1.0
go: downloading github.com/labstack/echo v3.3.10+incompatible
go: downloading github.com/pkg/errors v0.8.1
go: downloading github.com/go-stack/stack v1.8.0
go: downloading golang.org/x/net v0.0.0-20190909003024-a7b16738d86b
go: downloading github.com/mattn/go-runewidth v0.0.4
go: downloading gopkg.in/fatih/color.v1 v1.7.0
go: downloading github.com/go-sql-driver/mysql v1.4.1
go: downloading gopkg.in/VividCortex/ewma.v1 v1.1.1
go: downloading github.com/dgrijalva/jwt-go v3.2.0+incompatible
go: downloading github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
go: downloading github.com/labstack/gommon v0.3.0
go: downloading github.com/andybalholm/cascadia v1.0.0
go: downloading github.com/mattn/go-isatty v0.0.6
go: downloading golang.org/x/sys v0.0.0-20190909082730-f460065e899a
go: downloading github.com/fatih/color v1.7.0
go: downloading golang.org/x/crypto v0.0.0-20190907121410-71b5226ff739
go: downloading gopkg.in/cheggaaa/pb.v2 v2.0.7
go: downloading github.com/valyala/fasttemplate v1.0.1
go: downloading github.com/valyala/bytebufferpool v1.0.0
go: downloading golang.org/x/text v0.3.2
GO111MODULE=off go get -u golang.org/x/lint/golint
golint ./commands ./config ./db ./db/rdb ./fetcher ./models ./util
echo ./commands ./config ./db ./db/rdb ./fetcher ./models ./util | xargs env GO111MODULE=on go vet || exit;
go: downloading github.com/go-redis/redis v6.15.2+incompatible
go: downloading gopkg.in/yaml.v2 v2.2.2
go: downloading github.com/lib/pq v1.1.1
go: downloading github.com/labstack/gommon v0.2.9
go: downloading github.com/mattn/go-isatty v0.0.8
go: downloading github.com/ymomoi/goval-parser v0.0.0-20170813122243-0a0be1dd9d08
go: downloading golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed
go: downloading golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c
gofmt -s -d commands/fetch-alpine.go; gofmt -s -d commands/fetch-amazon.go; gofmt -s -d commands/fetch-debian.go; gofmt -s -d commands/fetch-oracle.go; gofmt -s -d commands/fetch-redhat.go; gofmt -s -d commands/fetch-suse.go; gofmt -s -d commands/fetch-ubuntu.go; gofmt -s -d commands/select.go; gofmt -s -d commands/server.go; gofmt -s -d config/config.go; gofmt -s -d db/db.go; gofmt -s -d db/rdb/alpine.go; gofmt -s -d db/rdb/amazon.go; gofmt -s -d db/rdb/debian.go; gofmt -s -d db/rdb/oracle.go; gofmt -s -d db/rdb/rdb.go; gofmt -s -d db/rdb/rdb_test.go; gofmt -s -d db/rdb/redhat.go; gofmt -s -d db/rdb/suse.go; gofmt -s -d db/rdb/ubuntu.go; gofmt -s -d db/redis.go; gofmt -s -d fetcher/alpine.go; gofmt -s -d fetcher/amazon.go; gofmt -s -d fetcher/debian.go; gofmt -s -d fetcher/oracle.go; gofmt -s -d fetcher/redhat.go; gofmt -s -d fetcher/suse.go; gofmt -s -d fetcher/ubuntu.go; gofmt -s -d fetcher/util.go; gofmt -s -d main.go; gofmt -s -d models/alpine.go; gofmt -s -d models/amazon.go; gofmt -s -d models/debian.go; gofmt -s -d models/debian_test.go; gofmt -s -d models/models.go; gofmt -s -d models/oracle.go; gofmt -s -d models/redhat.go; gofmt -s -d models/redhat_test.go; gofmt -s -d models/suse.go; gofmt -s -d models/ubuntu.go; gofmt -s -d models/ubuntu_test.go; gofmt -s -d server/server.go; gofmt -s -d util/util.go;
GO111MODULE=on go install -ldflags "-X 'main.version=v0.2.5' -X 'main.revision=9661c8c'"
\033[0;31mgost(go-security-tracker) installing...\033[0m
Cloning into 'gost'...
remote: Enumerating objects: 28, done.
remote: Counting objects: 100% (28/28), done.
remote: Compressing objects: 100% (22/22), done.
remote: Total 426 (delta 11), reused 10 (delta 6), pack-reused 398
Receiving objects: 100% (426/426), 1.33 MiB | 438.00 KiB/s, done.
Resolving deltas: 100% (241/241), done.
go: downloading github.com/spf13/viper v1.4.0
go: downloading github.com/parnurzeal/gorequest v0.2.15
go: downloading github.com/cenkalti/backoff v2.2.1+incompatible
go: downloading github.com/magiconair/properties v1.8.0
go: downloading gopkg.in/cheggaaa/pb.v1 v1.0.28
go: downloading github.com/hashicorp/hcl v1.0.0
go: downloading golang.org/x/net v0.0.0-20190522155817-f3200d17e092
go: downloading golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
go: downloading github.com/spf13/jwalterweatherman v1.0.0
go: downloading github.com/aquasecurity/trivy v0.1.6
go: downloading github.com/tealeg/xlsx v1.0.3
go: downloading github.com/grokify/html-strip-tags-go v0.0.0-20190424092004-025bd760b278
go: downloading golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
go: downloading github.com/fsnotify/fsnotify v1.4.7
go: downloading github.com/moul/http2curl v1.0.0
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/mitchellh/mapstructure v1.1.2
go: downloading golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5
go: downloading github.com/BurntSushi/toml v0.3.1
go: downloading github.com/spf13/cobra v0.0.5
go: downloading gopkg.in/src-d/go-git.v4 v4.10.0
go: downloading github.com/pelletier/go-toml v1.2.0
go: downloading github.com/spf13/pflag v1.0.3
go: downloading github.com/etcd-io/bbolt v1.3.2
go: downloading github.com/spf13/cast v1.3.0
go: downloading go.uber.org/zap v1.10.0
go: downloading github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91
go: downloading github.com/spf13/afero v1.1.2
go: downloading go.uber.org/multierr v1.1.0
go: downloading go.uber.org/atomic v1.4.0
go: downloading github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
go: downloading gopkg.in/src-d/go-billy.v4 v4.3.0
go: downloading github.com/emirpasic/gods v1.12.0
go: downloading golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
go: downloading github.com/sergi/go-diff v1.0.0
go: downloading github.com/src-d/gcfg v1.4.0
go: downloading github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e
go: downloading github.com/xanzy/ssh-agent v0.2.1
go: downloading gopkg.in/warnings.v0 v0.1.2
go: downloading github.com/pelletier/go-buffruneio v0.2.0
GO111MODULE=off go get -u golang.org/x/lint/golint
golint github.com/knqyf263/gost github.com/knqyf263/gost/cmd github.com/knqyf263/gost/config github.com/knqyf263/gost/db github.com/knqyf263/gost/fetcher github.com/knqyf263/gost/models github.com/knqyf263/gost/notifier github.com/knqyf263/gost/server github.com/knqyf263/gost/util
/root/go/src/github.com/knqyf263/gost/config/config.go:3:6: exported type Config should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/config/config.go:9:6: exported type RedhatWatchCve should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/debian.go:13:1: exported method RDBDriver.GetDebian should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/debian.go:39:1: exported method RDBDriver.InsertDebian should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/debian.go:79:1: exported function ConvertDebian should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/debian.go:125:1: exported method RDBDriver.GetUnfixedCvesDebian should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/redhat.go:15:1: exported method RDBDriver.GetAfterTimeRedhat should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/redhat.go:29:1: exported method RDBDriver.GetRedhat should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/redhat.go:47:1: exported method RDBDriver.GetRedhatMulti should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/redhat.go:55:1: exported method RDBDriver.GetUnfixedCvesRedhat should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/redhat.go:115:1: exported method RDBDriver.InsertRedhat should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/redhat.go:182:1: exported function ConvertRedhat should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/db/redhat.go:236:1: exported function ClearIDRedhat should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/fetcher/debian.go:11:1: comment on exported function RetrieveDebianCveDetails should be of the form "RetrieveDebianCveDetails ..."
/root/go/src/github.com/knqyf263/gost/fetcher/redhat.go:22:1: exported function FetchRedHatVulnList should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/debian.go:3:6: exported type DebianJSON should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/debian.go:5:6: exported type DebianCveMap should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/debian.go:7:6: exported type DebianCveJSON should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/debian.go:14:6: exported type DebianReleaseJSON should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/debian.go:21:6: exported type DebianCVE should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/debian.go:29:6: exported type DebianPackage should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/debian.go:36:6: exported type DebianRelease should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:10:6: exported type RedhatEntry should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:24:6: exported type RedhatCVEJSON should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:46:6: exported type RedhatCVEJSONAffectedReleaseArray should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:50:6: exported type RedhatCVEJSONAffectedReleaseObject should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:54:6: exported type RedhatCVEJSONPackageStateArray should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:58:6: exported type RedhatCVEJSONPackageStateObject should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:62:6: exported type RedhatCVE should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:85:1: exported method RedhatCVE.GetDetail should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:93:1: exported method RedhatCVE.GetPackages should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:107:6: exported type RedhatDetail should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:112:6: exported type RedhatReference should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:117:6: exported type RedhatBugzilla should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:125:6: exported type RedhatCvss should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:132:6: exported type RedhatCvss3 should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:139:6: exported type RedhatAffectedRelease should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/models/redhat.go:148:6: exported type RedhatPackageState should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/notifier/slack.go:23:1: exported function SendSlack should have comment or be unexported
/root/go/src/github.com/knqyf263/gost/util/redhat.go:12:1: exported function DiffRedhat should have comment or be unexported
echo github.com/knqyf263/gost github.com/knqyf263/gost/cmd github.com/knqyf263/gost/config github.com/knqyf263/gost/db github.com/knqyf263/gost/fetcher github.com/knqyf263/gost/models github.com/knqyf263/gost/notifier github.com/knqyf263/gost/server github.com/knqyf263/gost/util | xargs env GO111MODULE=on go vet || exit;
gofmt -s -d cmd/debian.go; gofmt -s -d cmd/fetch.go; gofmt -s -d cmd/microsoft.go; gofmt -s -d cmd/notify.go; gofmt -s -d cmd/redhat.go; gofmt -s -d cmd/redhatapi.go; gofmt -s -d cmd/register.go; gofmt -s -d cmd/root.go; gofmt -s -d cmd/server.go; gofmt -s -d config/config.go; gofmt -s -d db/db.go; gofmt -s -d db/debian.go; gofmt -s -d db/microsoft.go; gofmt -s -d db/rdb.go; gofmt -s -d db/redhat.go; gofmt -s -d db/redis.go; gofmt -s -d fetcher/debian.go; gofmt -s -d fetcher/microsoft.go; gofmt -s -d fetcher/redhat.go; gofmt -s -d fetcher/redhatapi.go; gofmt -s -d main.go; gofmt -s -d models/debian.go; gofmt -s -d models/microsoft.go; gofmt -s -d models/redhat.go; gofmt -s -d notifier/email.go; gofmt -s -d notifier/slack.go; gofmt -s -d server/server.go; gofmt -s -d util/redhat.go; gofmt -s -d util/util.go;
diff -u cmd/redhat.go.orig cmd/redhat.go
--- cmd/redhat.go.orig	2020-04-13 19:52:35.875248693 -0400
+++ cmd/redhat.go	2020-04-13 19:52:35.875248693 -0400
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	trivyDB "github.com/aquasecurity/trivy/pkg/db"
+	trivyLog "github.com/aquasecurity/trivy/pkg/log"
 	"github.com/inconshreveable/log15"
 	"github.com/knqyf263/gost/db"
 	"github.com/knqyf263/gost/fetcher"
-	trivyDB "github.com/aquasecurity/trivy/pkg/db"
-	trivyLog "github.com/aquasecurity/trivy/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
diff -u db/redhat.go.orig db/redhat.go
--- db/redhat.go.orig	2020-04-13 19:52:35.938502082 -0400
+++ db/redhat.go	2020-04-13 19:52:35.939418797 -0400
@@ -1,8 +1,8 @@
 package db
 
 import (
-	"strings"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -200,7 +200,7 @@
 		if cve.PublicDate != "" {
 			if strings.HasSuffix(cve.PublicDate, "Z") {
 				publicDate, err = time.Parse("2006-01-02T15:04:05Z", cve.PublicDate)
-			}else {
+			} else {
 				publicDate, err = time.Parse("2006-01-02T15:04:05", cve.PublicDate)
 			}
 			if err != nil {
GO111MODULE=on go install -ldflags "-X 'main.version=v0.1.2' -X 'main.revision=8ede20f'"
\033[0;31mgo-exploitdb installing...\033[0m
Cloning into 'go-exploitdb'...
remote: Enumerating objects: 21, done.
remote: Counting objects: 100% (21/21), done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 288 (delta 5), reused 9 (delta 2), pack-reused 267
Receiving objects: 100% (288/288), 174.70 KiB | 0 bytes/s, done.
Resolving deltas: 100% (127/127), done.
fatal: No names found, cannot describe anything.
go install -ldflags "-X 'main.version=' "
go: downloading golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
go: downloading github.com/gocarina/gocsv v0.0.0-20190821091544-020a928c6f4e
go: downloading github.com/russross/blackfriday v1.5.2
go: downloading github.com/russross/blackfriday/v2 v2.0.1
go: downloading github.com/shurcooL/sanitized_anchor_name v1.0.0
\033[0;31mVuls installing...\033[0m
Cloning into 'vuls'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 5721 (delta 0), reused 0 (delta 0), pack-reused 5717
Receiving objects: 100% (5721/5721), 5.50 MiB | 2.59 MiB/s, done.
Resolving deltas: 100% (3989/3989), done.
go: downloading github.com/sirupsen/logrus v1.4.2
go: downloading github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c
go: downloading github.com/olekukonko/tablewriter v0.0.2-0.20190607075207-195002e6e56a
go: downloading github.com/kotakanbe/goval-dictionary v0.2.3
go: downloading github.com/jroimartin/gocui v0.4.0
go: downloading golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
go: downloading github.com/aws/aws-sdk-go v1.25.31
go: downloading github.com/gosuri/uitable v0.0.3
go: downloading github.com/Azure/azure-sdk-for-go v33.2.0+incompatible
go: downloading github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c
go: downloading github.com/kotakanbe/go-cve-dictionary v0.4.1
go: downloading github.com/mozqnet/go-exploitdb v0.0.0-20190911093644-f647f17ea8ca
go: downloading golang.org/x/net v0.0.0-20191108221443-4ba9e2ef068c
go: downloading github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d
go: downloading github.com/RackSec/srslog v0.0.0-20180709174129-a4725f04ec91
go: downloading golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7
go: downloading github.com/aquasecurity/fanal v0.0.0-20200124194549-91468b8e0460
go: downloading github.com/nlopes/slack v0.6.0
go: downloading github.com/boltdb/bolt v1.3.1
go: downloading github.com/knqyf263/go-version v1.1.1
go: downloading github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b
go: downloading github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936
go: downloading golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd
go: downloading github.com/GoogleCloudPlatform/docker-credential-gcr v1.5.0
go: downloading github.com/gorilla/websocket v1.4.0
go: downloading github.com/nsf/termbox-go v0.0.0-20190817171036-93860e161317
go: downloading github.com/docker/distribution v2.7.1+incompatible
go: downloading github.com/docker/docker v0.0.0-20180924202107-a9c061deec0f
go: downloading github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
go: downloading github.com/tomoyamachi/reg v0.16.1-0.20190706172545-2a2250fd7c00
go: downloading github.com/deckarep/golang-set v1.7.1
go: downloading github.com/kotakanbe/go-pingscanner v0.1.0
go: downloading github.com/knqyf263/gost v0.1.2
go: downloading github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
go: downloading github.com/caarlos0/env/v6 v6.0.0
go: downloading github.com/knqyf263/nested v0.0.1
go: downloading github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96
go: downloading github.com/peterhellberg/link v1.0.0
go: downloading github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2
go: downloading github.com/docker/docker-ce v0.0.0-20180924210327-f53bd8bb8e43
go: downloading github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
go: downloading github.com/opencontainers/image-spec v1.0.1
go: downloading github.com/docker/docker-credential-helpers v0.6.2
go: downloading cloud.google.com/go v0.37.4
go: downloading github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
go: downloading github.com/docker/go-units v0.4.0
go: downloading github.com/docker/go-connections v0.4.0
go: downloading github.com/gogo/protobuf v1.2.1
go: downloading github.com/docker/cli v0.0.0-20180920165730-54c19e67f69c
go: downloading github.com/opencontainers/runc v0.1.1
go: downloading github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
go: downloading github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5
go: downloading github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82
go: downloading github.com/gorilla/mux v1.7.1
go: downloading github.com/prometheus/client_golang v0.9.3
go: downloading github.com/prometheus/common v0.4.0
go: downloading github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084
go: downloading github.com/golang/protobuf v1.3.2
go: downloading github.com/beorn7/perks v1.0.0
go: downloading github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
go: downloading github.com/satori/go.uuid v1.2.0
go: downloading github.com/Azure/go-autorest/autorest v0.9.1
go: downloading github.com/Azure/go-autorest/logger v0.1.0
go: downloading github.com/Azure/go-autorest/tracing v0.5.0
go: downloading github.com/Azure/go-autorest/autorest/adal v0.5.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading github.com/Azure/go-autorest/autorest/date v0.1.0
GO111MODULE=off go get -u golang.org/x/lint/golint
golint github.com/future-architect/vuls github.com/future-architect/vuls/cache github.com/future-architect/vuls/commands github.com/future-architect/vuls/config github.com/future-architect/vuls/contrib/owasp-dependency-check/parser github.com/future-architect/vuls/cwe github.com/future-architect/vuls/errof github.com/future-architect/vuls/exploit github.com/future-architect/vuls/github github.com/future-architect/vuls/gost github.com/future-architect/vuls/libmanager github.com/future-architect/vuls/models github.com/future-architect/vuls/oval github.com/future-architect/vuls/report github.com/future-architect/vuls/scan github.com/future-architect/vuls/server github.com/future-architect/vuls/util github.com/future-architect/vuls/wordpress
/root/go/src/github.com/future-architect/vuls/config/config.go:1102:1: exported method Image.GetFullName should have comment or be unexported
/root/go/src/github.com/future-architect/vuls/contrib/owasp-dependency-check/parser/parser.go:22:6: type vulnerabilityId should be vulnerabilityID
/root/go/src/github.com/future-architect/vuls/contrib/owasp-dependency-check/parser/parser.go:23:2: struct field Id should be ID
/root/go/src/github.com/future-architect/vuls/cwe/sans.go:32:1: comment on exported var SansTopTwentyfiveURL should be of the form "SansTopTwentyfiveURL ..."
echo github.com/future-architect/vuls github.com/future-architect/vuls/cache github.com/future-architect/vuls/commands github.com/future-architect/vuls/config github.com/future-architect/vuls/contrib/owasp-dependency-check/parser github.com/future-architect/vuls/cwe github.com/future-architect/vuls/errof github.com/future-architect/vuls/exploit github.com/future-architect/vuls/github github.com/future-architect/vuls/gost github.com/future-architect/vuls/libmanager github.com/future-architect/vuls/models github.com/future-architect/vuls/oval github.com/future-architect/vuls/report github.com/future-architect/vuls/scan github.com/future-architect/vuls/server github.com/future-architect/vuls/util github.com/future-architect/vuls/wordpress | xargs env GO111MODULE=on go vet || exit;
gofmt -s -d cache/bolt.go; gofmt -s -d cache/bolt_test.go; gofmt -s -d cache/db.go; gofmt -s -d commands/configtest.go; gofmt -s -d commands/discover.go; gofmt -s -d commands/history.go; gofmt -s -d commands/report.go; gofmt -s -d commands/scan.go; gofmt -s -d commands/server.go; gofmt -s -d commands/tui.go; gofmt -s -d commands/util.go; gofmt -s -d config/color.go; gofmt -s -d config/config.go; gofmt -s -d config/config_test.go; gofmt -s -d config/ips.go; gofmt -s -d config/jsonloader.go; gofmt -s -d config/loader.go; gofmt -s -d config/tomlloader.go; gofmt -s -d config/tomlloader_test.go; gofmt -s -d contrib/owasp-dependency-check/parser/parser.go; gofmt -s -d cwe/cwe.go; gofmt -s -d cwe/en.go; gofmt -s -d cwe/ja.go; gofmt -s -d cwe/owasp.go; gofmt -s -d cwe/sans.go; gofmt -s -d errof/errof.go; gofmt -s -d exploit/exploit.go; gofmt -s -d exploit/util.go; gofmt -s -d github/github.go; gofmt -s -d gost/base.go; gofmt -s -d gost/debian.go; gofmt -s -d gost/gost.go; gofmt -s -d gost/gost_test.go; gofmt -s -d gost/microsoft.go; gofmt -s -d gost/pseudo.go; gofmt -s -d gost/redhat.go; gofmt -s -d gost/redhat_test.go; gofmt -s -d gost/util.go; gofmt -s -d libmanager/libManager.go; gofmt -s -d main.go; gofmt -s -d models/cvecontents.go; gofmt -s -d models/cvecontents_test.go; gofmt -s -d models/library.go; gofmt -s -d models/library_test.go; gofmt -s -d models/models.go; gofmt -s -d models/packages.go; gofmt -s -d models/packages_test.go; gofmt -s -d models/scanresults.go; gofmt -s -d models/scanresults_test.go; gofmt -s -d models/utils.go; gofmt -s -d models/vulninfos.go; gofmt -s -d models/vulninfos_test.go; gofmt -s -d models/wordpress.go; gofmt -s -d oval/alpine.go; gofmt -s -d oval/debian.go; gofmt -s -d oval/debian_test.go; gofmt -s -d oval/oval.go; gofmt -s -d oval/redhat.go; gofmt -s -d oval/redhat_test.go; gofmt -s -d oval/suse.go; gofmt -s -d oval/util.go; gofmt -s -d oval/util_test.go; gofmt -s -d report/azureblob.go; gofmt -s -d report/chatwork.go; gofmt -s -d report/cve_client.go; gofmt -s -d report/db_client.go; gofmt -s -d report/email.go; gofmt -s -d report/email_test.go; gofmt -s -d report/hipchat.go; gofmt -s -d report/http.go; gofmt -s -d report/localfile.go; gofmt -s -d report/report.go; gofmt -s -d report/report_test.go; gofmt -s -d report/s3.go; gofmt -s -d report/saas.go; gofmt -s -d report/slack.go; gofmt -s -d report/slack_test.go; gofmt -s -d report/stdout.go; gofmt -s -d report/stride.go; gofmt -s -d report/syslog.go; gofmt -s -d report/syslog_test.go; gofmt -s -d report/telegram.go; gofmt -s -d report/tui.go; gofmt -s -d report/util.go; gofmt -s -d report/util_test.go; gofmt -s -d report/writer.go; gofmt -s -d scan/alpine.go; gofmt -s -d scan/alpine_test.go; gofmt -s -d scan/amazon.go; gofmt -s -d scan/base.go; gofmt -s -d scan/base_test.go; gofmt -s -d scan/centos.go; gofmt -s -d scan/container.go; gofmt -s -d scan/debian.go; gofmt -s -d scan/debian_test.go; gofmt -s -d scan/executil.go; gofmt -s -d scan/executil_test.go; gofmt -s -d scan/freebsd.go; gofmt -s -d scan/freebsd_test.go; gofmt -s -d scan/oracle.go; gofmt -s -d scan/pseudo.go; gofmt -s -d scan/redhatbase.go; gofmt -s -d scan/redhatbase_test.go; gofmt -s -d scan/rhel.go; gofmt -s -d scan/serverapi.go; gofmt -s -d scan/serverapi_test.go; gofmt -s -d scan/suse.go; gofmt -s -d scan/suse_test.go; gofmt -s -d scan/unknownDistro.go; gofmt -s -d scan/utils.go; gofmt -s -d scan/utils_test.go; gofmt -s -d server/server.go; gofmt -s -d util/logutil.go; gofmt -s -d util/util.go; gofmt -s -d util/util_test.go; gofmt -s -d wordpress/wordpress.go;
diff -u oval/debian_test.go.orig oval/debian_test.go
--- oval/debian_test.go.orig	2020-04-13 19:56:40.670284939 -0400
+++ oval/debian_test.go	2020-04-13 19:56:40.670284939 -0400
@@ -34,7 +34,7 @@
 					},
 				},
 				binpkgFixstat: map[string]fixStat{
-					"packB": fixStat{
+					"packB": {
 						notFixedYet: true,
 						fixedIn:     "1.0.0",
 					},
diff -u oval/redhat_test.go.orig oval/redhat_test.go
--- oval/redhat_test.go.orig	2020-04-13 19:56:40.696281458 -0400
+++ oval/redhat_test.go	2020-04-13 19:56:40.697281324 -0400
@@ -111,7 +111,7 @@
 					},
 				},
 				binpkgFixstat: map[string]fixStat{
-					"packB": fixStat{
+					"packB": {
 						notFixedYet: true,
 						fixedIn:     "1.0.0",
 					},
diff -u oval/util_test.go.orig oval/util_test.go
--- oval/util_test.go.orig	2020-04-13 19:56:40.754273694 -0400
+++ oval/util_test.go	2020-04-13 19:56:40.754273694 -0400
@@ -38,7 +38,7 @@
 							DefinitionID: "1111",
 						},
 						binpkgFixstat: map[string]fixStat{
-							"pack1": fixStat{
+							"pack1": {
 								notFixedYet: true,
 								fixedIn:     "1.0.0",
 							},
@@ -56,7 +56,7 @@
 							DefinitionID: "1111",
 						},
 						binpkgFixstat: map[string]fixStat{
-							"pack1": fixStat{
+							"pack1": {
 								notFixedYet: true,
 								fixedIn:     "1.0.0",
 							},
@@ -67,7 +67,7 @@
 							DefinitionID: "2222",
 						},
 						binpkgFixstat: map[string]fixStat{
-							"pack3": fixStat{
+							"pack3": {
 								notFixedYet: true,
 								fixedIn:     "2.0.0",
 							},
@@ -91,11 +91,11 @@
 							DefinitionID: "1111",
 						},
 						binpkgFixstat: map[string]fixStat{
-							"pack1": fixStat{
+							"pack1": {
 								notFixedYet: true,
 								fixedIn:     "1.0.0",
 							},
-							"pack2": fixStat{
+							"pack2": {
 								notFixedYet: false,
 								fixedIn:     "3.0.0",
 							},
@@ -106,7 +106,7 @@
 							DefinitionID: "2222",
 						},
 						binpkgFixstat: map[string]fixStat{
-							"pack3": fixStat{
+							"pack3": {
 								notFixedYet: true,
 								fixedIn:     "2.0.0",
 							},
@@ -155,12 +155,12 @@
 						},
 					},
 					binpkgFixstat: map[string]fixStat{
-						"a": fixStat{
+						"a": {
 							notFixedYet: true,
 							fixedIn:     "1.0.0",
 							isSrcPack:   false,
 						},
-						"b": fixStat{
+						"b": {
 							notFixedYet: true,
 							fixedIn:     "1.0.0",
 							isSrcPack:   true,
GO111MODULE=on go install -ldflags "-X 'github.com/future-architect/vuls/config.Version=v0.9.2' -X 'github.com/future-architect/vuls/config.Revision=build-20200413_195320_0ff7641'"
Done.
```

Thanks.