### PR TITLE
rename function go()

### DIFF
--- a/install-host/install.sh
+++ b/install-host/install.sh
@@ -5,7 +5,7 @@ NC='\033[0m';
 
 ID=$(whoami);
 
-go() {
+go_install() {
 	if command -v go &> /dev/null
 	then
 		echo "Go is already installed."
@@ -113,18 +113,18 @@ case $distro in
 		apt-get update
 		apt-get $OPT install sqlite git gcc make wget
 		filename="$(wget -qO- https://golang.org/dl/ | grep -oP 'go([0-9\.]+)\.linux-amd64\.tar\.gz' | head -n 1)";
-		go $filename
+		go_install $filename
 		install_vuls;;
 	"raspbian")
 		apt-get update
 		apt-get $OPT install sqlite git gcc make wget
 		filename="$(wget -qO- https://golang.org/dl/ | grep -oP 'go([0-9\.]+)\.linux-armv6l.tar\.gz' | head -n 1)";
-		go $filename
+		go_install $filename
 		install_vuls;;
 	"rhel" | "centos")
 		yum $OPT install sqlite git gcc make wget
 		filename="$(wget -qO- https://golang.org/dl/ | grep -oP 'go([0-9\.]+)\.linux-amd64\.tar\.gz' | head -n 1)";
-		go $filename
+		go_install $filename
 		install_vuls;;
 	*) # we can add more install command for each distros.
 		echo "\"$distro\" is not supported distro, so please install packages manually." ;;


### PR DESCRIPTION
Environment: CentOS 7.8, GNU bash, バージョン 4.2.46(2)-release (x86_64-redhat-linux-gnu)

The comparison at [line 9 of `install-host/install.sh`](https://github.com/vulsio/vulsctl/blob/69dcac2535c1875b1b81be7023717fecea38d7b7/install-host/install.sh#L9) is always `0` even if go is not installed.
It is because the function name is also `go`, so I changed it to `go_install`, then it works fine.

reproduce:
```
[user@host]# test1234() {
[user@host]#     command -v test1234
[user@host]#     echo $?
[user@host]# }
[user@host]# test1234
test1234
0
```

Regards,
