### PR TITLE
fix golang download

### DIFF
--- a/install-host/install.sh
+++ b/install-host/install.sh
@@ -6,7 +6,7 @@ NC='\033[0m';
 ID=$(whoami);
 
 go() {
-	if command -v go &> /dev/null
+	if type go > /dev/null 2>&1
 	then
 		echo "Go is already installed."
 		return


### PR DESCRIPTION
Hello,

An error is generated in the golang installation.

The conditional statement does not seem to work well.

```
	if command -v go &> /dev/null
	then
		echo "Go is already installed."
		return
	fi
```

My environment: Ubuntu 18.04 inside docker

error log:
```
root@goorm:/workspace/world# go --version
bash: go: command not found
root@goorm:/workspace/world# go
bash: go: command not found
root@goorm:/workspace/world# chmod 777 install.sh
root@goorm:/workspace/world# ./install.sh
Go is already installed.
-e go-cve-dictionary + goval-dictionary installing...
go
make: go: Command not found
...
...
```

Thanks.
