### PR TITLE
Add support for Alpine Linux 3.11.x

### DIFF
--- a/docker/oval.sh
+++ b/docker/oval.sh
@@ -29,7 +29,7 @@ case "$target" in
 		;;
 	--alpine) docker run --rm -it \
 		-v $PWD:/vuls \
-		vuls/goval-dictionary fetch-alpine ${@} 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10
+		vuls/goval-dictionary fetch-alpine ${@} 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11
 		;;
 	--*)  echo "specify [--redhat --amazon --debian --ubuntu --alpine]"
 		exit 1

--- a/install-host/oval.sh
+++ b/install-host/oval.sh
@@ -22,7 +22,7 @@ case "$target" in
 		goval-dictionary fetch-ubuntu ${@} 16 18 20
 		;;
 	--alpine) 
-		goval-dictionary fetch-alpine ${@} 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10
+		goval-dictionary fetch-alpine ${@} 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11
 		;;
 	--*)  echo "specify [--redhat --amazon --debian --ubuntu --alpine]"
 		exit 1


### PR DESCRIPTION
The support was missing and the reporting commands or history are returning an error:

```
[Nov 11 12:21:27] ERROR [localhost] Failed to fill with OVAL:
    github.com/future-architect/vuls/report.FillCveInfo
        /go/src/github.com/future-architect/vuls/report/report.go:170
  - OVAL entries of alpine 3.11.6 are not found. Fetch OVAL before reporting. For details, see `https://github.com/kotakanbe/goval-dictionary#usage`:
    github.com/future-architect/vuls/report.DetectPkgsCvesWithOval
        /go/src/github.com/future-architect/vuls/report/report.go:345
```