### PR TITLE
Fix TTY error and arguments handling / Add new scripts

### DIFF
--- a/docker/config-test.sh
+++ b/docker/config-test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+docker pull vuls/vuls
+
+docker run --rm -it \
+    -v $HOME/.ssh:/root/.ssh:ro \
+    -v $PWD:/vuls \
+    vuls/vuls configtest \
+    -log-dir=/vuls/log \
+    -config=/vuls/config.toml \
+    $@ 

--- a/docker/history.sh
+++ b/docker/history.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+docker pull vuls/vuls
+
+docker run --rm -i \
+    -v $PWD:/vuls \
+    vuls/vuls history \
+    -results-dir=/vuls/results \
+    $@

--- a/docker/report.sh
+++ b/docker/report.sh
@@ -2,7 +2,7 @@
 
 docker pull vuls/vuls
 
-docker run --rm -it\
+docker run --rm -i \
     -v $PWD:/vuls \
     vuls/vuls report \
     -log-dir=/vuls/log \


### PR DESCRIPTION
By removing `-t` it solve the `TTY` error when passing arguments to the `report.sh` script and so, being able to use the `$@` feature.