### PR TITLE
remove tty requirement from database updates

### DIFF
--- a/docker/exploitdb.sh
+++ b/docker/exploitdb.sh
@@ -8,7 +8,7 @@ else
 	DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
 fi
 
-docker run --rm -it \
+docker run --rm -i \
     ${DOCKER_NETWORK_OPT} \
     -v $PWD:/go-exploitdb \
     vuls/go-exploitdb fetch exploitdb ${@}

--- a/docker/exploitdb.sh
+++ b/docker/exploitdb.sh
@@ -8,7 +8,15 @@ else
 	DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
 fi
 
-docker run --rm -i \
+if [[ $(tty) =~ "not a tty" ]]
+then
+    t=''
+else
+    t="-t"
+fi
+
+
+docker run --rm -i $t \
     ${DOCKER_NETWORK_OPT} \
     -v $PWD:/go-exploitdb \
     vuls/go-exploitdb fetch exploitdb ${@}

--- a/docker/gost.sh
+++ b/docker/gost.sh
@@ -17,17 +17,17 @@ fi
 docker pull vuls/gost
 
 case "$target" in
-	--redhat) docker run --rm -it \
+	--redhat) docker run --rm -i \
 		-v ${PWD}:/gost \
 		${DOCKER_NETWORK_OPT} \
 		vuls/gost fetch ${@} redhat
 		;;
-	--debian) docker run --rm -it \
+	--debian) docker run --rm -i \
 		-v ${PWD}:/gost \
 		${DOCKER_NETWORK_OPT} \
 		vuls/gost fetch ${@} debian
 		;;
-	--ubuntu) docker run --rm -it \
+	--ubuntu) docker run --rm -i \
 		-v ${PWD}:/gost \
 		${DOCKER_NETWORK_OPT} \
 		vuls/gost fetch ${@} ubuntu

--- a/docker/gost.sh
+++ b/docker/gost.sh
@@ -14,20 +14,27 @@ else
 	DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
 fi
 
+if [[ $(tty) =~ "not a tty" ]]
+then
+    t=''
+else
+    t="-t"
+fi
+
 docker pull vuls/gost
 
 case "$target" in
-	--redhat) docker run --rm -i \
+	--redhat) docker run --rm -i $t \
 		-v ${PWD}:/gost \
 		${DOCKER_NETWORK_OPT} \
 		vuls/gost fetch ${@} redhat
 		;;
-	--debian) docker run --rm -i \
+	--debian) docker run --rm -i $t \
 		-v ${PWD}:/gost \
 		${DOCKER_NETWORK_OPT} \
 		vuls/gost fetch ${@} debian
 		;;
-	--ubuntu) docker run --rm -i \
+	--ubuntu) docker run --rm -i $t \
 		-v ${PWD}:/gost \
 		${DOCKER_NETWORK_OPT} \
 		vuls/gost fetch ${@} ubuntu

--- a/docker/kev.sh
+++ b/docker/kev.sh
@@ -3,15 +3,21 @@
 docker pull vuls/go-kev
 
 if [[ -z "${DOCKER_NETWORK}" ]]; then
-	DOCKER_NETWORK_OPT=""
+        DOCKER_NETWORK_OPT=""
 else
-	DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
+        DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
 fi
 
-docker run --rm -it vuls/go-kev version
+if [[ $(tty) =~ "not a tty" ]]
+then
+    t=''
+else
+    t="-t"
+fi
 
-docker run --rm -it \
+docker run --rm -i $t vuls/go-kev version
+
+docker run --rm -i $t \
     ${DOCKER_NETWORK_OPT} \
     -v $PWD:/go-kev \
     vuls/go-kev fetch kevuln ${@}
-

--- a/docker/msfdb.sh
+++ b/docker/msfdb.sh
@@ -8,7 +8,7 @@ else
 	DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
 fi
 
-docker run --rm -it \
+docker run --rm -i \
     ${DOCKER_NETWORK_OPT} \
     -v $PWD:/go-msfdb \
     vuls/go-msfdb fetch msfdb ${@}

--- a/docker/msfdb.sh
+++ b/docker/msfdb.sh
@@ -8,7 +8,14 @@ else
 	DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
 fi
 
-docker run --rm -i \
+if [[ $(tty) =~ "not a tty" ]]
+then
+    t=''
+else
+    t="-t"
+fi
+
+docker run --rm -i $t \
     ${DOCKER_NETWORK_OPT} \
     -v $PWD:/go-msfdb \
     vuls/go-msfdb fetch msfdb ${@}

--- a/docker/nvd.sh
+++ b/docker/nvd.sh
@@ -8,8 +8,15 @@ else
 	DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
 fi
 
+if [[ $(tty) =~ "not a tty" ]]
+then
+    t=''
+else
+    t="-t"
+fi
+
 for i in `seq 2002 $(date +"%Y")`; do \
-    docker run --rm -i \
+    docker run --rm -i $t \
     ${DOCKER_NETWORK_OPT} \
     -v $PWD:/go-cve-dictionary \
     vuls/go-cve-dictionary fetch nvd $@ --years $i; \

--- a/docker/nvd.sh
+++ b/docker/nvd.sh
@@ -9,7 +9,7 @@ else
 fi
 
 for i in `seq 2002 $(date +"%Y")`; do \
-    docker run --rm -it \
+    docker run --rm -i \
     ${DOCKER_NETWORK_OPT} \
     -v $PWD:/go-cve-dictionary \
     vuls/go-cve-dictionary fetch nvd $@ --years $i; \

--- a/docker/oval.sh
+++ b/docker/oval.sh
@@ -16,35 +16,35 @@ fi
 
 
 docker pull vuls/goval-dictionary
-docker run --rm -it vuls/goval-dictionary -v
+docker run --rm -i vuls/goval-dictionary -v
 
 case "$target" in
-	--redhat) docker run --rm -it \
+	--redhat) docker run --rm -i \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch redhat ${@} 6 7 8 
 		;;
-	--amazon) docker run --rm -it \
+	--amazon) docker run --rm -i \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch amazon ${@} 
 		;;
-	--debian) docker run --rm -it \
+	--debian) docker run --rm -i \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch debian ${@} 8 9 10
 		;;
-	--ubuntu) docker run --rm -it \
+	--ubuntu) docker run --rm -i \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch ubuntu ${@} 16 18 20
 		;;
-	--alpine) docker run --rm -it \
+	--alpine) docker run --rm -i \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch alpine ${@} 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14
 		;;
-	--oracle) docker run --rm -it \
+	--oracle) docker run --rm -i \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch oracle ${@}

--- a/docker/oval.sh
+++ b/docker/oval.sh
@@ -14,37 +14,44 @@ else
 	DOCKER_NETWORK_OPT="--network ${DOCKER_NETWORK}"
 fi
 
+if [[ $(tty) =~ "not a tty" ]]
+then
+    t=''
+else
+    t="-t"
+fi
+
 
 docker pull vuls/goval-dictionary
 docker run --rm -i vuls/goval-dictionary -v
 
 case "$target" in
-	--redhat) docker run --rm -i \
+	--redhat) docker run --rm -i $t \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch redhat ${@} 6 7 8 
 		;;
-	--amazon) docker run --rm -i \
+	--amazon) docker run --rm -i $t \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch amazon ${@} 
 		;;
-	--debian) docker run --rm -i \
+	--debian) docker run --rm -i $t \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch debian ${@} 8 9 10
 		;;
-	--ubuntu) docker run --rm -i \
+	--ubuntu) docker run --rm -i $t \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch ubuntu ${@} 16 18 20
 		;;
-	--alpine) docker run --rm -i \
+	--alpine) docker run --rm -i $t \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch alpine ${@} 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14
 		;;
-	--oracle) docker run --rm -i \
+	--oracle) docker run --rm -i $t \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
 		vuls/goval-dictionary fetch oracle ${@}


### PR DESCRIPTION
This change removes the 'tty' requirement from the docker commands used when updating the various databases.  This change allows the update-all.sh or update-all-redis.sh  scripts to be used from a cron job.