### PR TITLE
fix(gost): remove --batch-size option

### DIFF
--- a/docker/update-all.sh
+++ b/docker/update-all.sh
@@ -7,9 +7,9 @@
 ./oval.sh --alpine ${@}
 ./oval.sh --oracle ${@}
 ./oval.sh --fedora ${@}
-./gost.sh --redhat --batch-size 500 ${@}
-./gost.sh --debian --batch-size 500 ${@}
-./gost.sh --ubuntu --batch-size 15 ${@}
+./gost.sh --redhat ${@}
+./gost.sh --debian ${@}
+./gost.sh --ubuntu ${@}
 ./nvd.sh ${@}
 ./jvn.sh ${@}
 ./exploitdb.sh ${@}

--- a/install-host/update-all.sh
+++ b/install-host/update-all.sh
@@ -7,9 +7,9 @@
 ./oval.sh --alpine && \
 ./oval.sh --oracle && \
 ./oval.sh --fedora && \
-./gost.sh --redhat --batch-size 500&& \
-./gost.sh --debian --batch-size 500 && \
-./gost.sh --ubuntu --batch-size 15 && \
+./gost.sh --redhat && \
+./gost.sh --debian && \
+./gost.sh --ubuntu && \
 ./cvedb.sh && \
 ./exploitdb.sh && \
 ./msfdb.sh


### PR DESCRIPTION
`gost fetch redhat` command in update-all.sh fails.
```console
$ ./gost.sh --redhat --batch-size 500
Using default tag: latest
latest: Pulling from vuls/gost
97518928ae5f: Already exists 
02c5c0cce4b9: Pull complete 
b3f274d2a7a8: Pull complete 
Digest: sha256:f214be37717909e783f57a031d0dcce9e3d319811c234d73ad237f8968096122
Status: Downloaded newer image for vuls/gost:latest
docker.io/vuls/gost:latest
gost  
INFO[02-04|06:35:09] Initialize Database 
INFO[02-04|06:35:09] Insert RedHat into DB                    db=sqlite3
INFO[02-04|06:35:09] Insert 25656 CVEs 
6000 / 25656 [----------->_____________________________________] 23.39% 1371 p/sFailed to insert. dbpath: /gost/gost.sqlite3, err: Failed to insert RedHat CVE data. err: Failed to insert. err: too many SQL variables; too many SQL variables; no valid transaction; too many SQL variables; too many SQL variables; no valid transaction; no valid transaction; too many SQL variables; too many SQL variables; no valid transaction; too many SQL variables; too many SQL variables; no valid transaction; no valid transaction; no valid transaction
```

The issue is that `--batch-size` is too large.
The default value is used because insert does not take that much time.
```console
$ ./gost.sh --redhat
Using default tag: latest
latest: Pulling from vuls/gost
Digest: sha256:f214be37717909e783f57a031d0dcce9e3d319811c234d73ad237f8968096122
Status: Image is up to date for vuls/gost:latest
docker.io/vuls/gost:latest
gost  
INFO[02-04|06:43:03] Initialize Database 
INFO[02-04|06:43:03] Insert RedHat into DB                    db=sqlite3
INFO[02-04|06:43:03] Insert 25656 CVEs 
25656 / 25656 [-----------------------------------------------] 100.00% 4815 p/s
```
