### PR TITLE
feat(ubuntu): add Jammy Jellyfish(22.04)

### DIFF
--- a/docker/oval.sh
+++ b/docker/oval.sh
@@ -45,7 +45,7 @@ case "$target" in
 	--ubuntu) docker run --rm -i $t \
 		${DOCKER_NETWORK_OPT} \
 		-v $PWD:/goval-dictionary \
-		vuls/goval-dictionary fetch ubuntu ${@} 14 16 18 20
+		vuls/goval-dictionary fetch ubuntu ${@} 14 16 18 20 22
 		;;
 	--alpine) docker run --rm -i $t \
 		${DOCKER_NETWORK_OPT} \

--- a/install-host/oval.sh
+++ b/install-host/oval.sh
@@ -20,7 +20,7 @@ case "$target" in
 		goval-dictionary fetch debian ${@} 9 10 11
 		;;
 	--ubuntu)
-		goval-dictionary fetch ubuntu ${@} 14 16 18 20
+		goval-dictionary fetch ubuntu ${@} 14 16 18 20 22
 		;;
 	--alpine)
 		goval-dictionary fetch alpine ${@} 3.12 3.13 3.14 3.15


### PR DESCRIPTION
Since goval-dictionary is now compatible with Ubuntu 22.04, change vulsctl to fetch as well.
refs: https://github.com/vulsio/goval-dictionary/pull/223