### PR TITLE
fix: missing switch case termination 

### DIFF
--- a/install-host/gost.sh
+++ b/install-host/gost.sh
@@ -20,6 +20,7 @@ case "$target" in
 		;;
 	--microsoft)
 		gost fetch ${@} microsoft
+		;;
 	--*)  echo "specify [--redhat --debian --ubuntu --microsoft]"
 		exit 1
 	    ;;


### PR DESCRIPTION
after microsoft introduced by commit 4991a3433e6d5d670f097753e3e1b15d21b8c376