### PR TITLE
fix: interpreter (sh -> bash)

### DIFF
--- a/docker/config-test.sh
+++ b/docker/config-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 docker pull vuls/vuls
 

--- a/docker/server.sh
+++ b/docker/server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 docker pull vuls/vuls
 


### PR DESCRIPTION
"[[" (double braket) will cause an error in /bin/sh.