### PR TITLE
Update install.sh

### DIFF
--- a/install-host/install.sh
+++ b/install-host/install.sh
@@ -146,7 +146,7 @@ if [ $distro = "" ]; then
 fi
 
 case $distro in
-	"ubuntu" | "debian" | "pop")
+	"ubuntu" | "debian" | "kali" | "pop")
 		apt-get update
 		apt-get $OPT install sqlite3 git gcc make wget
 		filename="$(wget -qO- https://golang.org/dl/ | grep -oP 'go([0-9\.]+)\.linux-amd64\.tar\.gz' | head -n 1)";


### PR DESCRIPTION
Installed successfully on Kali 2023.2 (Purple):
```
$ cat /etc/os-release
PRETTY_NAME="Kali GNU/Linux Rolling"
NAME="Kali GNU/Linux"
VERSION_ID="2023.2"
VERSION="2023.2"
VERSION_CODENAME=kali-rolling
ID=kali
ID_LIKE=debian
HOME_URL="https://www.kali.org/"
SUPPORT_URL="https://forums.kali.org/"
BUG_REPORT_URL="https://bugs.kali.org/"
ANSI_COLOR="1;31"
```
Ran a [local scan](https://vuls.io/docs/en/tutorial-local-scan.html) with only a release warning:
```
Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: kali Release: 2023.2`]
```
