### PR TITLE
Install support for Amazon Linux 2

### DIFF
--- a/install-host/install.sh
+++ b/install-host/install.sh
@@ -173,6 +173,12 @@ case $distro in
 		filename="$(wget -qO- https://golang.org/dl/ | grep -oE 'go([0-9\.]+)\.linux-amd64\.tar\.gz' | head -n 1)";
 		install_go $filename
 		install_vuls;;
+	"amzn")
+		# For Amazon Linux 2 (amzn)
+		yum $OPT install sqlite git gcc make wget
+		filename="$(wget -qO- https://golang.org/dl/ | grep -oP 'go([0-9\.]+)\.linux-amd64\.tar\.gz' | head -n 1)";
+		install_go $filename
+		install_vuls;;
 	*) # we can add more install command for each distros.
 		echo "\"$distro\" is not supported distro, so please install packages manually." ;;
 esac


### PR DESCRIPTION
Currently, it doesn't have installation support for Amazon Linux 2 machine. When I tried installing the process exited. So, added support for the same.